### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name":"riconeitzel/vertical-navigation",
+    "type":"magento-module",
+    "license":"OSL-3.0",
+    "homepage":"https://github.com/riconeitzel/VertNav",
+    "description":"Vertical Navigation with CSS Classes.",
+    "authors":[
+        {
+            "name":"Rico Neitzel"
+        },
+        {
+            "name":"Vinai Kopp",
+            "email":"vinai@netzarbeiter.com"
+        }
+    ],
+    "require":{
+        "magento-hackathon/magento-composer-installer":"dev-master"
+    }
+}


### PR DESCRIPTION
Hi Rico,

the composer.json enables the installation of the extension via composer.
Background: during the hackathon our team built a comopser installer for Magento modules with modman files.
One the composer.json is added, Vertnav could be installed directly if the GitHub repo is listed directly in the projects composer config, plus, it can also be listed on the Magento module repository at http://packages.firegento.com/ (I'd take care of adding it there if you want).

More info:
composer: http://getcomposer.org/
magento-composer-installer: https://github.com/magento-hackathon/magento-composer-installer
